### PR TITLE
Tweak backend dockerfile

### DIFF
--- a/backend_server/Dockerfile
+++ b/backend_server/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.7.5-slim-stretch
+FROM python:3.7-slim-stretch
 
 WORKDIR /python-back-end
 
-ADD . /python-back-end
+COPY . /python-back-end
 
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
Use 3.7 image and follow minor updates instead of locking it.
Use COPY in place of ADD as recommended by official docker documentation.