### PR TITLE
modified url navigation in history view, and added not found component

### DIFF
--- a/frontend/src/components/BranchFilter.js
+++ b/frontend/src/components/BranchFilter.js
@@ -1,9 +1,11 @@
 // eslint-disable-next-line
 import React, { useState, useEffect, useCallback } from 'react';
+import { useHistory } from "react-router-dom";
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core';
 import { useStateValue } from '../contexts/state';
 import theme from '../theme';
+
 
 const BranchFilter = () => {
   const filterStyles = css`
@@ -79,6 +81,7 @@ const BranchFilter = () => {
   ] = useStateValue();
   const options = branchesState;
   const selectedBuild = selectedBuildState.id;
+  const history = useHistory()
 
   // Local component states
   const [suggestions, setSuggestions] = useState([]);
@@ -90,14 +93,10 @@ const BranchFilter = () => {
   const fetchData = async (builds, series_id, build_id) => {
     dispatch({ type: 'setLoadingState', loadingState: true });
     try {
-      const res = await fetch(
-        `/data/history?builds=${builds}&series=${series_id}`,
-        //`/data/history?start_from=${build_id}&series=${series_id}&builds=${builds}`,
-        {}
-      );
-      const json = await res.json();
+      const url = ('/history/'+series_id+'/'+builds+'/')
+      history.push(url);
       dispatch({ type: 'setLoadingState', loadingState: false });
-      dispatch({ type: 'updateHistory', historyData: json });
+      //dispatch({ type: 'updateHistory', historyData: json });
     } catch (error) {
       //
     }
@@ -129,13 +128,11 @@ const BranchFilter = () => {
       const branch = options.series.find(
         ({ name }) => name === clickedBranchName
       );
-      console.log(branch);
       dispatch({
         type: 'setSelectedBranch',
         name: branchAndTeam,
         id: branch.id
       });
-      //this.props.history.push('/history/',branch.id,'/','30','/')
       fetchData(amountOfBuilds, branch.id, selectedBuild);
     } catch (error) {
       // console.log('clicked branch not found')

--- a/frontend/src/components/MainNav.js
+++ b/frontend/src/components/MainNav.js
@@ -4,7 +4,6 @@ import { NavLink } from 'react-router-dom';
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core';
 import ThemeContext from '../contexts/themeContext';
-import { useStateValue } from '../contexts/state';
 
 const MainNav = () => {
   const theme = useContext(ThemeContext);
@@ -66,27 +65,6 @@ const MainNav = () => {
       }
     }
   `;
-  const [{ historyDataState }, dispatch] = useStateValue();
-  const maxBuildNum = historyDataState ? historyDataState.max_build_num : null;
-
-  const handleClick = () => {
-    if (maxBuildNum) {
-      dispatch({
-        type: 'setSelectedBuild',
-        selectedBuild: maxBuildNum
-      });
-    }
-  };
-
-  const handleKeyDown = e => {
-    if (e.key === 'Enter' && maxBuildNum) {
-      dispatch({
-        type: 'setSelectedBuild',
-        selectedBuild: maxBuildNum
-      });
-    }
-  };
-
   return (
     <nav id="main-nav" css={mainNavStyles}>
       <h2 className="logo">Epimetheus</h2>
@@ -101,21 +79,6 @@ const MainNav = () => {
             History
           </NavLink>
         </li>
-        {/* 
-        Commented out at the moment, can be implemented in the future to show some exact place wanted,
-        currently worked as a hard coded series, ideas on what to show here and should an implementation like this
-        be used are welcome. 
-        <li>
-          <NavLink
-            activeClassName="active"
-            to={`/build/series/${maxBuildNum}/3`}
-            onClick={() => handleClick()}
-            onKeyDown={e => handleKeyDown(e)}
-          >
-            Last Build
-          </NavLink>
-        </li>
-        */}
         <li className="nav-github">
           <a href="https://github.com/salabs/Epimetheus">GitHub</a>
         </li>

--- a/frontend/src/components/NotFound.js
+++ b/frontend/src/components/NotFound.js
@@ -6,6 +6,7 @@ class Notfound extends Component {
     return <div>
       <h2 style={{ marginBottom: 0 }}>404</h2>
       <h4 style={{ marginTop: 0 }}>No Results Found with your parameters.</h4>
+      <h4 style={{ marginTop: 0 }}>Try switching the series.</h4>
     </div>
   }
 }

--- a/frontend/src/components/historyTable/Table.js
+++ b/frontend/src/components/historyTable/Table.js
@@ -4,6 +4,8 @@ import React, { useContext } from 'react';
 import { css, jsx } from '@emotion/core';
 import Heading from './Heading';
 import Body from './Body';
+import NotFound from '../NotFound';
+import { useStateValue } from '../../contexts/state';
 
 const Table = () => {
   const tableStyles = css`
@@ -36,17 +38,29 @@ const Table = () => {
       vertical-align: middle;
     }
   `;
+  const [
+    {
+      historyDataState: { max_build_num },
+    },
+  ] = useStateValue();
 
-  return (
-    <div css={tableStyles}>
-      <table id="history-table">
-        <Heading />
-        <tbody id="history-table-body">
-          <Body />
-        </tbody>
-      </table>
-    </div>
-  );
+  if (max_build_num > 0) {
+    return (
+      <div css={tableStyles}>
+        <table id="history-table">
+          <Heading />
+          <tbody id="history-table-body">
+            <Body />
+          </tbody>
+        </table>
+      </div>
+    );
+  } else {
+    return (
+      <NotFound/>
+    );
+  }
+
 };
 
 export default Table;


### PR DESCRIPTION
History view now changes the url when switching between series and branches, 
Done with React.Router 5 useHistory hook, works quite okey. 

Also added a new component that is rendered instead of the table if there are no results from the backend query, the content for that component can be later modified. 