### PR TITLE
Add css focus styling for accessibility

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -119,6 +119,10 @@ const App = () => {
       border: 1px solid black;
       text-align: center;
       z-index: 999;
+    },
+    select:focus,
+    input:focus {
+      outline: 1px solid ${theme.testTheme.linkColor};
     }
   `;
 


### PR DESCRIPTION
Flagged by Firefox accessibility checker. Makes it easier to see where the focus is.