### PR TITLE
backend: separates All builds series from teams end point, fixes seri…

### DIFF
--- a/backend_server/database.py
+++ b/backend_server/database.py
@@ -36,7 +36,7 @@ class Database:
         self.session = queries.TornadoSession(connection_uri)
 
     def test_series(self):
-        return self.session.query(sql_queries.TEST_SERIES), list_of_dicts
+        return self.session.query(sql_queries.test_series()), list_of_dicts
 
     def teams(self):
         def series_by_team(rows):
@@ -48,14 +48,18 @@ class Database:
                 if current_team_name != series['team']:
                     if current_team:
                         teams.append(current_team)
-                    current_team = {'name': series['team'], 'series_count': 0, 'series': []}
-                current_team['series_count'] += 1
-                current_team['series'].append(series)
-                current_team_name = series['team']
+                    current_team = {'name': series['team'], 'series_count': 0, 'series': [],
+                                    'all_builds': None}
+                if series['name'] == 'All builds':
+                    current_team['all_builds'] = series
+                else:
+                    current_team['series_count'] += 1
+                    current_team['series'].append(series)
+                    current_team_name = series['team']
             if current_team:
                 teams.append(current_team)
             return teams
-        return self.session.query(sql_queries.TEST_SERIES_BY_TEAMS), series_by_team
+        return self.session.query(sql_queries.test_series(by_teams=True)), series_by_team
 
     def history_page_data(self, test_series, start_from, num_of_builds, offset):
         history_sql = sql_queries.history_page_data(test_series, start_from, num_of_builds, offset)

--- a/backend_server/sql_queries.py
+++ b/backend_server/sql_queries.py
@@ -1,11 +1,14 @@
 
-TEST_SERIES = """
+def test_series(by_teams=False):
+    return """
 SELECT id, name, team,
         count(*) as builds,
         max(build_number) as last_build,
-        to_char(max(generated), 'DD.MM.YYYY HH24:MI:SS') as last_generated,
-        to_char(max(imported_at), 'DD.MM.YYYY HH24:MI:SS') as last_imported,
-        to_char(max(start_time), 'DD.MM.YYYY HH24:MI:SS') as last_started
+        max(generated) as last_generated,
+        max(imported_at) as last_imported,
+        max(start_time) as last_started,
+        CASE WHEN max(start_time) IS NOT NULL THEN max(start_time)
+             ELSE max(imported_at) END as sorting_value
 FROM (
     SELECT test_series.id, name, team, build_number,
             min(generated) as generated,
@@ -19,31 +22,10 @@ FROM (
     GROUP BY test_series.id, name, team, build_number
 ) AS builds
 GROUP BY id, name, team
-ORDER BY last_generated DESC, last_started DESC, last_imported DESC;
-"""
+ORDER BY {team_sorting} sorting_value;
+""".format(team_sorting="team," if by_teams else '') # nosec
+# No user input is actually used here so query construction here is okay
 
-TEST_SERIES_BY_TEAMS = """
-SELECT id, name, team,
-        count(*) as builds,
-        max(build_number) as last_build,
-        to_char(max(generated), 'DD.MM.YYYY HH24:MI:SS') as last_generated,
-        to_char(max(imported_at), 'DD.MM.YYYY HH24:MI:SS') as last_imported,
-        to_char(max(start_time), 'DD.MM.YYYY HH24:MI:SS') as last_started
-FROM (
-    SELECT test_series.id, name, team, build_number,
-            min(generated) as generated,
-            min(imported_at) as imported_at,
-            min(start_time) as start_time
-    FROM test_series
-    JOIN test_series_mapping as tsm ON tsm.series=test_series.id
-    JOIN test_run ON tsm.test_run_id=test_run.id
-    JOIN suite_result ON suite_result.test_run_id=test_run.id
-    WHERE NOT ignored
-    GROUP BY test_series.id, name, team, build_number
-) AS builds
-GROUP BY id, name, team
-ORDER BY team, last_generated DESC, last_started DESC, last_imported DESC;
-"""
 
 def test_run_ids(series=None, build_num=None, start_from=None, last=None, offset=0):
     filters = []

--- a/backend_server/tests/requirements.txt
+++ b/backend_server/tests/requirements.txt
@@ -1,0 +1,2 @@
+robotframework==3.1.2
+RESTinstance==1.0.2

--- a/backend_server/tests/robot/api/basic.robot
+++ b/backend_server/tests/robot/api/basic.robot
@@ -21,6 +21,16 @@ Teams data
     GET                 /data/teams
     String              $.teams[*].name
     Integer             $.teams[*].series_count
+
+    Object              $.teams[*].all_builds
+    Integer             $.teams[*].all_builds.id
+    String              $.teams[*].all_builds.name
+    String              $.teams[*].all_builds.team
+    String              $.teams[*].all_builds.last_imported
+    String              $.teams[*].all_builds.last_started
+    Integer             $.teams[*].all_builds.builds
+    Integer             $.teams[*].all_builds.last_build
+
     Array               $.teams[*].series     minItems=1
     Integer             $.teams[*].series[*].id
     String              $.teams[*].series[*].name


### PR DESCRIPTION
…es ordering with iso timestamps

- The special All builds series is listed and counted as separate item in teams end point
- Makes seires data to use iso formatted timestamps instesad of custom formatting
- More consistent ordering of series by available timestamps
- Adds backend tests specific requirement.txt file