### PR TITLE
Feature/editorconfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# https://editorconfig.org/
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,7 @@ Examples of contributions include:
 *   Bug reports and patch reviews
 
 Patches can be submitted as pull requests, but if you don't file an issue, it may be ignored. Please file an issue to suggest changes.
+
+## Coding style
+Epimetheus project uses [EditorConfig](https://editorconfig.org/) to manage the coding style. See the [.editorconfig](/.editorconfig) file
+for settings.


### PR DESCRIPTION
Adds EditorConfig for managing coding style. Property end_of_line is not defined because it is left to version control system to handle ref. https://github.com/editorconfig/editorconfic/wiki/EditorConfig-Properties .