### PR TITLE
Modernise depricated api calls to the current syntax

### DIFF
--- a/frontend/src/pages/Build.js
+++ b/frontend/src/pages/Build.js
@@ -59,7 +59,7 @@ const Build = () => {
             if (branch_id && buildId) {
                 try {
                     const res = await fetch(
-                        `/data/metadata?series=${branch_id}&build_number=${buildId}`,
+                        `/data/series/${branch_id}/builds/${buildId}/metadata`,
                         {}
                     );
                     const json = await res.json();
@@ -88,8 +88,7 @@ const Build = () => {
                 dispatch({ type: 'setSelectedBuild', selectedBuild: buildId });
                 try {
                     const res = await fetch(
-                        ///`/data/history?series=${id}&builds=30`,
-                        `/data/history?start_from=${buildId}&series=${branch_id}&builds=5`,
+                        `/data/series/${branch_id}/history?start_from=${buildId}&builds=5`,
                         {}
                     );
                     const json = await res.json();

--- a/frontend/src/pages/History.js
+++ b/frontend/src/pages/History.js
@@ -63,7 +63,7 @@ const History = () => {
   const number_of_builds = builds || amountOfBuilds || '30';
 
   useEffect(() => {
-    const url = `/data/history?builds=${number_of_builds}&series=${series_id}`;
+    const url = `/data/series/${series_id}/history?builds=${number_of_builds}`;
     if (branchesState) {
       const branch = branchesState.series?.find(
         ({ id: serie_id }) => serie_id === parseInt(series_id, 10)


### PR DESCRIPTION
Backend has moved forward while the frontend has been calling old API endpoints. Fixed that so there's no more calls to the two depreciated versions of the endpoints.

* `Build.js` — changed the history endpoint and the metadata endpoints to the modern variants
* `History.js` — changed the history endpoint to the modern variant