### PR TITLE
Feature/team card updates

### DIFF
--- a/frontend/src/components/Card.js
+++ b/frontend/src/components/Card.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import theme from '../styles/theme';
+import { useTranslation } from 'react-i18next';
 
 const Card = ({ team, numberOfSeries }) => {
+    const [t] = useTranslation(['team']);
     let history = useHistory();
+
     return (
         <div
             style={theme.flexItem}
@@ -11,7 +14,9 @@ const Card = ({ team, numberOfSeries }) => {
             role={'presentation'}
         >
             <h3>{team}</h3>
-            <div>Number of series: {numberOfSeries}</div>
+            <div>
+                {t('series')}: {numberOfSeries}
+            </div>
         </div>
     );
 };

--- a/frontend/src/components/SelectedTeam.js
+++ b/frontend/src/components/SelectedTeam.js
@@ -62,7 +62,9 @@ const SelectedTeam = ({ selectedTeam }) => {
                     <hr />
                     <div
                         className="builds"
-                        onClick={() => history.push(`/history/${id}/10`)}
+                        onClick={() =>
+                            history.push(`/history/${id}/10/${last_build}`)
+                        }
                         role={'presentation'}
                     >
                         <h4>Last build</h4>

--- a/frontend/src/components/SelectedTeam.js
+++ b/frontend/src/components/SelectedTeam.js
@@ -30,7 +30,7 @@ const SelectedTeam = ({ selectedTeam }) => {
         flexWrap: 'wrap'
     };
 
-    const TeamCard = ({ serie }) => {
+    const TeamCard = ({ data }) => {
         const {
             id,
             name,
@@ -39,7 +39,7 @@ const SelectedTeam = ({ selectedTeam }) => {
             last_build_id,
             last_started,
             last_status
-        } = serie;
+        } = data;
 
         const LastStarted = last_started.slice(0, 16);
         const testStatusIcon = pickIcon(last_status);
@@ -84,57 +84,9 @@ const SelectedTeam = ({ selectedTeam }) => {
             <BreadcrumbNav status={'team'} />
             {selectedTeam && selectedTeam.all_builds ? (
                 <div style={flexContainer}>
-                    {/* <div
-                        style={theme.flexItem}
-                        onClick={() =>
-                            history.push(
-                                `/history/${selectedTeam.all_builds.id}/10`
-                            )
-                        }
-                        role={'presentation'}
-                    >
-                        <h3>{selectedTeam.all_builds.name}</h3>
-                        <hr />
-                        <div style={cardItem}>
-                            <div>
-                                <FA name="clock-o" />{' '}
-                                {selectedTeam.all_builds.last_started.slice(
-                                    0,
-                                    16
-                                )}
-                            </div>
-                            <div>
-                                <FA name="hashtag" />{' '}
-                                {selectedTeam.all_builds.last_build}
-                            </div>
-                        </div>
-                    </div> */}
-                    <TeamCard serie={selectedTeam.all_builds} />
+                    <TeamCard data={selectedTeam.all_builds} />
                     {selectedTeam.series.reverse().map((serie, i) => {
-                        return (
-                            // <div
-                            //     style={theme.flexItem}
-                            //     key={i}
-                            //     onClick={() =>
-                            //         history.push(`/history/${element.id}/10`)
-                            //     }
-                            //     role={'presentation'}
-                            // >
-                            //     <h3>{element.name}</h3>
-                            //     <hr />
-                            //     <div style={cardItem}>
-                            //         <div>
-                            //             <FA name="clock-o" />{' '}
-                            //             {element.last_started.slice(0, 16)}
-                            //         </div>
-                            //         <div>
-                            //             <FA name="hashtag" />{' '}
-                            //             {element.last_build}
-                            //         </div>
-                            //     </div>
-                            // </div>
-                            <TeamCard key={i} serie={serie} />
-                        );
+                        return <TeamCard key={i} data={serie} />;
                     })}
                 </div>
             ) : (

--- a/frontend/src/components/SelectedTeam.js
+++ b/frontend/src/components/SelectedTeam.js
@@ -5,11 +5,14 @@ import { useHistory } from 'react-router-dom';
 import theme from '../styles/theme';
 import BreadcrumbNav from './BreadcrumbNav';
 import { pickIcon } from './TestIcon';
+import { useTranslation } from 'react-i18next';
 
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core';
 
 const SelectedTeam = ({ selectedTeam }) => {
+    const [t] = useTranslation(['team']);
+
     const cardStyles = css`
         background-color: #fafafa;
         box-shadow: rgba(0, 0, 0, 0.16) 0px 3px 4px,
@@ -56,8 +59,8 @@ const SelectedTeam = ({ selectedTeam }) => {
                         onClick={() => history.push(`/history/${id}/10`)}
                         role={'presentation'}
                     >
-                        <h4>Series</h4>
-                        Number of builds: {builds}
+                        <h4>{t('card.series.title')}</h4>
+                        {t('card.series.builds')}: {builds}
                     </div>
                     <hr />
                     <div
@@ -67,14 +70,14 @@ const SelectedTeam = ({ selectedTeam }) => {
                         }
                         role={'presentation'}
                     >
-                        <h4>Last build</h4>
-                        Build number: {last_build}
+                        <h4>{t('card.last_build.title')}</h4>
+                        {t('card.last_build.build_number')}: {last_build}
                         <br />
-                        Build id: {last_build_id}
+                        {t('card.last_build.build_id')}: {last_build_id}
                         <br />
-                        Last build started: {LastStarted}
+                        {t('card.last_build.last_build_started')}: {LastStarted}
                         <br />
-                        Last status: {testStatusIcon}
+                        {t('card.last_build.last_status')}: {testStatusIcon}
                     </div>
                 </div>
             </div>

--- a/frontend/src/locales/en/team.json
+++ b/frontend/src/locales/en/team.json
@@ -1,0 +1,17 @@
+﻿{
+    "title": "Teams",
+    "series": "Number of series",
+    "card": {
+        "series": {
+            "title": "Series",
+            "builds": "Number of builds"
+        },
+        "last_build": {
+            "title": "Last build",
+            "build_number": "Build number",
+            "build_id": "Build id",
+            "last_build_started": "Last build started",
+            "last_status": "Last status"
+        }
+    }
+}

--- a/frontend/src/pages/Team.js
+++ b/frontend/src/pages/Team.js
@@ -4,8 +4,10 @@ import Card from '../components/Card';
 import { useParams } from 'react-router';
 import SelectedTeam from '../components/SelectedTeam';
 import Loading from '../components/Loading';
+import { useTranslation } from 'react-i18next';
 
 const Team = () => {
+    const [t] = useTranslation(['team']);
     const [{ loadingState, teamsState }, dispatch] = useStateValue();
 
     const { name } = useParams();
@@ -20,7 +22,7 @@ const Team = () => {
                 dispatch({ type: 'setLoadingState', loadingState: false });
                 dispatch({ type: 'setTeams', teams: json.teams });
             } catch (error) {
-                console.log(error);
+                dispatch({ type: 'setErrorState', errorState: error });
             }
         };
         fetchData();
@@ -38,8 +40,8 @@ const Team = () => {
                 />
             ) : (
                 <div>
-                    <h1>Teams</h1>
-                    {teamsState.map(({ name, series_count, series }, i) => {
+                    <h1>{t('title')}</h1>
+                    {teamsState.map(({ name, series_count }, i) => {
                         return (
                             <Card
                                 team={name}

--- a/frontend/src/styles/theme.js
+++ b/frontend/src/styles/theme.js
@@ -13,7 +13,8 @@ const theme = {
         boxShadow: '0 3px 4px rgba(0,0,0,0.16), 0 3px 4px rgba(0,0,0,0.23)',
         margin: '10px',
         padding: '10px',
-        minHeight: '20vh'
+        minHeight: '20vh',
+        backgroundColor: '#fafafa'
     },
     baseTableStyle: `
       table {

--- a/frontend/src/utils/i118n.js
+++ b/frontend/src/utils/i118n.js
@@ -2,21 +2,21 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import frontpage from '../locales/en/frontpage.json';
 import mainnav from '../locales/en/mainnav.json';
+import team from '../locales/en/team.json';
 
 const resources = {
-  en: {
-    frontpage,
-    mainnav
-  }
+    en: {
+        frontpage,
+        mainnav,
+        team
+    }
 };
 
-i18n
-  .use(initReactI18next)
-  .init({
+i18n.use(initReactI18next).init({
     resources,
     lng: 'en',
     debug: false,
     interpolation: {
-      escapeValue: false
-    },
-  });
+        escapeValue: false
+    }
+});


### PR DESCRIPTION
The team(s) page has cards that represent the series/branches related to that team. In the current implementation, the cards have little information and they are links to the history view of the series.

The cards should have two sections:
- section containing the data related to the series
- section for the info about the last build

Series info:
- name
- number builds in this series
- This should be a link to the history view of the series

Last build info:
- build number (integer)
- build id (a string, defaults to the build number if not specified)
- Start time for the last build
- Link to the single build view