### PR TITLE
Keep backend running if database is empty

### DIFF
--- a/backend_server/database.py
+++ b/backend_server/database.py
@@ -32,7 +32,6 @@ class Database:
                 session.query('SELECT count(*) FROM test_run')
         except Exception:
             print('ERROR: Given database is empty. Consider archiving some results first.')
-            sys.exit(1)
 
         self.session = queries.TornadoSession(connection_uri)
 


### PR DESCRIPTION
This makes it easier to setup Epimetheus on container environment
where the database is not yet initialised. With exit() in place,
backend container would keep terminating until database has data.
Initialising system is easier when all containers keep running.