### PR TITLE
Bug/133 - Checkbox accessibility fix

### DIFF
--- a/frontend/src/components/buttons/LastRunCheckbox.jsx
+++ b/frontend/src/components/buttons/LastRunCheckbox.jsx
@@ -16,7 +16,7 @@ import {
 import { useQueryParams } from '../../hooks/useQuery';
 import { useHistory, useLocation } from 'react-router-dom';
 
-const Checkbox = ({ direction }) => {
+const LastRunCheckbox = ({ direction }) => {
     // eslint-disable-next-line
     const [{ lastRunFilterPass, lastRunFilterFail }, dispatch] = useStateValue();
     const [passFilter, setPassFilter] = useState(lastRunFilterPass.isChecked);
@@ -111,4 +111,4 @@ const Checkbox = ({ direction }) => {
     );
 };
 
-export default Checkbox;
+export default LastRunCheckbox;

--- a/frontend/src/components/buttons/LastRunCheckbox.styles.js
+++ b/frontend/src/components/buttons/LastRunCheckbox.styles.js
@@ -25,16 +25,31 @@ export const StyledDiv = styled.div`
     span {
         padding-right: 8px;
         position: relative;
-        top: -1.5px;
+        top: -1px;
+
+        svg {
+            position: relative;
+            top: -1px;
+        }
     }
 `;
 
 export const StyledLabel = styled.label`
     margin-right: 20px;
     display: block;
-    float: left;
+    position: relative;
 `;
 
 export const StyledInput = styled.input`
-    display: none;
+    appearance: none;
+    opacity: 0;
+    position: absolute;
+    top: 3px;
+    height: 16px;
+    width: 16px;
+    border-radius: 2px;
+
+    &:focus {
+        opacity: 1;
+    }
 `;

--- a/frontend/src/pages/History.jsx
+++ b/frontend/src/pages/History.jsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import Table from '../components/historyTable/Table';
 import ParentSeries from '../components/parentData/ParentSeries';
 import Offset from '../components/buttons/OffSetButtons';
-import Checkbox from '../components/buttons/LastRunCheckbox';
+import LastRunCheckbox from '../components/buttons/LastRunCheckbox';
 import BuildAmountSelector from '../components/buttons/BuildAmountSelector';
 import { useStateValue } from '../contexts/state';
 import { useParams } from 'react-router';
@@ -107,7 +107,7 @@ const History = () => {
                     <FilterContainer id="filter-container">
                         <BuildAmountSelector />
                         <Offset />
-                        <Checkbox direction="row" />
+                        <LastRunCheckbox direction="row" />
                     </FilterContainer>
                     {!historyDataState || loadingState ? (
                         <Loading />


### PR DESCRIPTION
Merge [#132 ](https://github.com/salabs/Epimetheus/pull/132) before this because it has new focus styles for inputs. 

Style guide's current focus styles with the color _Sparkling blue_ are not accessible because the color ratio is only 2.02:1 so this is something that needs to be reconsidered later on.