### PR TITLE
Added fallback to missing last started value

### DIFF
--- a/frontend/src/components/card/SeriesCard.jsx
+++ b/frontend/src/components/card/SeriesCard.jsx
@@ -24,9 +24,20 @@ const SeriesCard = ({ data }) => {
         last_build_id,
         last_started,
         last_status,
+        last_imported,
     } = data;
 
-    const LastStarted = last_started.slice(0, 16);
+    let LastStarted;
+    const LastStartedFallBack = '';
+    try {
+        LastStarted = last_started.slice(0, 16);
+    } catch(e) {
+        if (last_imported !== null) {
+            LastStarted = last_imported.slice(0, 16);
+        } else {
+            LastStarted = LastStartedFallBack;
+        }
+    }
     const testStatusIcon = pickIcon(last_status);
     return (
         <CardSection aria-label={name} grid={true}>


### PR DESCRIPTION
If last_started value is missing from the data, we'll try to use the import time of the test results in their place (which should always be present in the data)

Currently the application died when trying the slice operation for a null value, so this fixes said behaviour.
Especially useful when working with outputs from other frameworks than robot.